### PR TITLE
test: use function factory instead of {mockery}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Imports:
 Suggests: 
     devtools,
     knitr,
-    mockery,
     rmarkdown,
     testthat (>= 3.0.0),
     withr

--- a/tests/testthat/helper_mock.R
+++ b/tests/testthat/helper_mock.R
@@ -1,0 +1,26 @@
+# the function below is a function factory, a function that creates and returns
+# another function
+
+# it create a mock object that returns user inputs in sequence
+
+# outer function initialises the index. inner function increments counter i
+# every time it is called and returns i-th element in the responses vector
+
+# The <<- operator is used to modify the i variable in the parent environment
+# (the environment of helper_mock)
+
+# new_mock <- helper_mock("3", "This is a note", "n")
+# new_mock()  # [1] "3"
+# new_mock()  # [1] "This is a note"
+# new_mock()  # [1] "n"
+# new_mock()  # [1] NA
+# new_mock()  # [1] NA
+
+helper_mock <- function(...) {
+  responses <- c(...)
+  i <- 0
+  function(...) {
+    i <<- i + 1
+    responses[i]
+  }
+}

--- a/tests/testthat/test-user_categorisation.R
+++ b/tests/testthat/test-user_categorisation.R
@@ -1,18 +1,9 @@
 test_that("user_categorisation works with valid input", {
-  # create a mock object that returns user inputs in sequence
-  mock_factory <- function(...) {
-    i <- 0
 
-    function(...) {
-      things <- c("3", "This is a note", "n")
-      i <<- i + 1
-      things[i]
-    }
-  }
   # replace `readline` function within the `user_categorisation` function with
-  # the `mock_readline` mock object
+  # the `helper-mock_factory.R` mock object
   local_mocked_bindings(
-    readline = mock_factory()
+    readline = helper_mock("3", "This is a note", "n")
   )
 
   response <- user_categorisation(var = "Variable1",
@@ -22,11 +13,9 @@ test_that("user_categorisation works with valid input", {
 })
 
 test_that("user_categorisation handles invalid input and then valid input", {
-  # create a mock object that returns invalid input first, then valid input
-  mock_readline <- mockery::mock("6", "3", "This is a note", "n")
-  # replace `readline` function within the `user_categorisation` function with
-  # the `mock_readline` mock object
-  mockery::stub(user_categorisation, "readline", mock_readline)
+  local_mocked_bindings(
+    readline = helper_mock("6", "3", "This is a note", "n")
+  )
 
   response <- user_categorisation(var = "Variable1",
                                   desc = "Description1",
@@ -35,12 +24,9 @@ test_that("user_categorisation handles invalid input and then valid input", {
 })
 
 test_that("user_categorisation handles multiple valid inputs", {
-  # create a mock object that returns multiple valid inputs
-  mock_readline <- mockery::mock("3,4", "This is another note", "n")
-  # replace `readline` function within the `user_categorisation` function with
-  # the `mock_readline` mock object
-  mockery::stub(user_categorisation, "readline", mock_readline)
-
+  local_mocked_bindings(
+    readline = helper_mock("3,4", "This is another note", "n")
+  )
   response <- user_categorisation(var = "Variable1",
                                   desc = "Description1",
                                   type = "Type1", domain_code_max = 5)
@@ -49,12 +35,10 @@ test_that("user_categorisation handles multiple valid inputs", {
 })
 
 test_that("user_categorisation handles re-do input", {
-  # create a mock object that returns inputs including re-do
-  mock_readline <- mockery::mock("3", "This is a note", "y", "4",
-                                 "Another note", "n")
-  # replace `readline` function within the `user_categorisation` function with
-  # the `mock_readline` mock object
-  mockery::stub(user_categorisation, "readline", mock_readline)
+  local_mocked_bindings(
+    readline = helper_mock("3", "This is a note", "y", "4",
+                           "Another note", "n")
+  )
 
   response <- user_categorisation(var = "Variable1",
                                   desc = "Description1",

--- a/tests/testthat/test-user_categorisation.R
+++ b/tests/testthat/test-user_categorisation.R
@@ -1,9 +1,19 @@
 test_that("user_categorisation works with valid input", {
   # create a mock object that returns user inputs in sequence
-  mock_readline <- mockery::mock("3", "This is a note", "n")
+  mock_factory <- function(...) {
+    i <- 0
+
+    function(...) {
+      things <- c("3", "This is a note", "n")
+      i <<- i + 1
+      things[i]
+    }
+  }
   # replace `readline` function within the `user_categorisation` function with
   # the `mock_readline` mock object
-  mockery::stub(user_categorisation, "readline", mock_readline)
+  local_mocked_bindings(
+    readline = mock_factory()
+  )
 
   response <- user_categorisation(var = "Variable1",
                                   desc = "Description1",


### PR DESCRIPTION
Reference: https://adv-r.hadley.nz/function-factories.html#factory-fundamentals

``` r
mock_factory <- function(...) {
  i <- 0
  
  function(...) {
    things <- c("3", "This is a note", "n")
    i <<- i + 1
    things[i]
  }
}

new_mock <- mock_factory()
new_mock()
#> [1] "3"
new_mock()
#> [1] "This is a note"
new_mock()
#> [1] "n"
new_mock()
#> [1] NA
```

<sup>Created on 2025-02-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>